### PR TITLE
Updating README conversation privacy policy

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,6 +47,8 @@ Failing to follow the community guidelines as described in this document carries
 
 #### Privacy
 - All conversations are private unless otherwise specified. 
+  - The lone exception is in the event of seeking mediation or reporting behavior in volation of the code of conduct. In this case conversations may be shared with a member of the administrative team who may in turn share it with the rest of the administrative team if discussion is required.”
+
 - If you wish to share a conversation, or part of one, you must get permission from each person involved.
 
 ### Best Practices

--- a/README.md
+++ b/README.md
@@ -47,7 +47,7 @@ Failing to follow the community guidelines as described in this document carries
 
 #### Privacy
 - All conversations are private unless otherwise specified. 
-  - The lone exception is in the event of seeking mediation or reporting behavior in volation of the code of conduct. In this case conversations may be shared with a member of the administrative team who may in turn share it with the rest of the administrative team if discussion is required.
+  - The lone exception is in the event of seeking mediation or reporting behavior in violation of the code of conduct. In this case conversations may be shared with a member of the administrative team who may in turn share it with the rest of the administrative team if discussion is required.
 
 - If you wish to share a conversation, or part of one, you must get permission from each person involved.
 

--- a/README.md
+++ b/README.md
@@ -47,7 +47,7 @@ Failing to follow the community guidelines as described in this document carries
 
 #### Privacy
 - All conversations are private unless otherwise specified. 
-  - The lone exception is in the event of seeking mediation or reporting behavior in volation of the code of conduct. In this case conversations may be shared with a member of the administrative team who may in turn share it with the rest of the administrative team if discussion is required.”
+  - The lone exception is in the event of seeking mediation or reporting behavior in volation of the code of conduct. In this case conversations may be shared with a member of the administrative team who may in turn share it with the rest of the administrative team if discussion is required.
 
 - If you wish to share a conversation, or part of one, you must get permission from each person involved.
 

--- a/README.md
+++ b/README.md
@@ -47,7 +47,7 @@ Failing to follow the community guidelines as described in this document carries
 
 #### Privacy
 - All conversations are private unless otherwise specified. 
-  - The lone exception is in the event of seeking mediation or reporting behavior in violation of the code of conduct. In this case conversations may be shared with a member of the administrative team who may in turn share it with the rest of the administrative team if discussion is required.
+  - The only exceptions to this rule pertain to the enforcement of our code of conduct. A conversation may be shared with any member of the administrative team when a violation of the code of conduct has occurred. The conversation may then be reviewed by the entire administrative team, if necessary, to determine an appropriate resolution.
 
 - If you wish to share a conversation, or part of one, you must get permission from each person involved.
 


### PR DESCRIPTION
Adding a new term to the privacy policy to allow conversations to be shared with the admin team for the purposes of moderation.